### PR TITLE
Add back navigation links from child pages to index

### DIFF
--- a/Big_Data_Processing.html
+++ b/Big_Data_Processing.html
@@ -86,6 +86,7 @@
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <h1 class="text-2xl font-bold text-slate-800">Big Data & Cloud</h1>
             <div class="hidden md:flex space-x-8">
+                <a href="index.html" class="nav-link text-slate-600 font-medium">Home</a>
                 <a href="#introduction" class="nav-link text-slate-600 font-medium">Introduction</a>
                 <a href="#concepts" class="nav-link text-slate-600 font-medium">Core Concepts</a>
                 <a href="#cloud" class="nav-link text-slate-600 font-medium">Cloud Integration</a>
@@ -96,6 +97,7 @@
             </button>
         </nav>
         <div id="mobile-menu" class="hidden md:hidden">
+            <a href="index.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Home</a>
             <a href="#introduction" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Introduction</a>
             <a href="#concepts" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Core Concepts</a>
             <a href="#cloud" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Cloud Integration</a>

--- a/Big_Data_Storage_Concepts.html
+++ b/Big_Data_Storage_Concepts.html
@@ -36,6 +36,7 @@
                 </div>
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-4">
+                        <a href="index.html" class="nav-link text-slate-600 hover:text-blue-500 px-3 py-2 rounded-md text-sm font-medium border-b-2 inactive-nav">Home</a>
                         <a href="#cluster-computing" class="nav-link text-slate-600 hover:text-blue-500 px-3 py-2 rounded-md text-sm font-medium border-b-2 inactive-nav">Cluster Computing</a>
                         <a href="#data-distribution" class="nav-link text-slate-600 hover:text-blue-500 px-3 py-2 rounded-md text-sm font-medium border-b-2 inactive-nav">Data Distribution</a>
                         <a href="#comparative-analysis" class="nav-link text-slate-600 hover:text-blue-500 px-3 py-2 rounded-md text-sm font-medium border-b-2 inactive-nav">Comparative Analysis</a>

--- a/Map_Reduce.html
+++ b/Map_Reduce.html
@@ -106,6 +106,7 @@
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <h1 class="text-2xl font-bold text-primary">MapReduce Explained</h1>
             <div class="hidden md:flex space-x-8">
+                <a href="index.html" class="nav-link">Home</a>
                 <a href="#introduction" class="nav-link active-nav">Intro</a>
                 <a href="#simulation" class="nav-link">Simulation</a>
                 <a href="#flow" class="nav-link">How It Works</a>
@@ -118,6 +119,7 @@
             </button>
         </nav>
         <div id="mobile-menu" class="hidden md:hidden bg-white">
+            <a href="index.html" class="block py-2 px-4 text-sm nav-link">Home</a>
             <a href="#introduction" class="block py-2 px-4 text-sm nav-link">Intro</a>
             <a href="#simulation" class="block py-2 px-4 text-sm nav-link">Simulation</a>
             <a href="#flow" class="block py-2 px-4 text-sm nav-link">How It Works</a>

--- a/NoSQL_Deep_Dive.html
+++ b/NoSQL_Deep_Dive.html
@@ -67,15 +67,17 @@
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <h1 class="text-2xl font-bold text-slate-800">NoSQL Explained</h1>
             <div class="hidden md:flex items-center space-x-8">
+                <a href="index.html" class="nav-link font-medium pb-1">Home</a>
                 <a href="#concepts" class="nav-link font-medium pb-1">Concepts</a>
                 <a href="#types" class="nav-link font-medium pb-1">Types</a>
                 <a href="#applications" class="nav-link font-medium pb-1">Applications</a>
                 <a href="#future" class="nav-link font-medium pb-1">Future</a>
                 <a href="#products" class="nav-link font-medium pb-1">Products</a>
             </div>
-            <div class="md:hidden">
+            <div class="md:hidden flex items-center space-x-4">
+                <a href="index.html" class="text-slate-600 font-medium">Home</a>
                 <select id="mobile-nav" class="bg-slate-100 border border-slate-300 rounded-md p-2 text-slate-700">
-                    <option value="#hero">Home</option>
+                    <option value="#hero">Intro</option>
                     <option value="#concepts">Concepts</option>
                     <option value="#types">Types</option>
                     <option value="#applications">Applications</option>


### PR DESCRIPTION
## Summary
- Add Home link to header and mobile menus in Big Data Processing page
- Add Home navigation to Big Data Storage, Map Reduce, and NoSQL Deep Dive pages

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c207f22a48325b852d9c61d5cafee