### PR TITLE
Add navigation for Levels of Data Analytics page

### DIFF
--- a/Hadoop_Fundamentals.html
+++ b/Hadoop_Fundamentals.html
@@ -115,6 +115,7 @@
         <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
             <h1 class="text-2xl font-bold text-slate-800">Hadoop Fundamentals</h1>
             <div class="hidden md:flex space-x-8">
+                <a href="index.html" class="nav-link text-slate-600 font-medium">Home</a>
                 <a href="#intro" class="nav-link text-slate-600 font-medium">Introduction</a>
                 <a href="#hdfs" class="nav-link text-slate-600 font-medium">HDFS</a>
                 <a href="#yarn" class="nav-link text-slate-600 font-medium">YARN</a>
@@ -126,6 +127,7 @@
             </button>
         </nav>
         <div id="mobile-menu" class="hidden md:hidden">
+            <a href="index.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Home</a>
             <a href="#intro" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Introduction</a>
             <a href="#hdfs" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">HDFS</a>
             <a href="#yarn" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">YARN</a>

--- a/Levels_of_Data_Analytics.html
+++ b/Levels_of_Data_Analytics.html
@@ -63,11 +63,18 @@
 </head>
 <body class="scroll-smooth">
 
+    <header class="bg-[#ece5e1] shadow-sm">
+        <nav class="container mx-auto px-6 py-4 flex justify-end">
+            <a href="index.html" class="text-[#63534d] hover:underline font-medium">Home</a>
+        </nav>
+    </header>
+
     <div class="flex min-h-screen">
         <!-- Sidebar Navigation -->
         <aside class="w-64 sticky top-0 h-screen bg-[#ece5e1] p-6 hidden lg:flex flex-col">
             <h1 class="text-2xl font-bold text-[#63534d] mb-8">Data Analytics</h1>
             <nav id="desktop-nav" class="flex flex-col space-y-2">
+                <a href="index.html" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">Home</a>
                 <a href="#intro" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">Introduction</a>
                 <a href="#descriptive" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">1. Descriptive</a>
                 <a href="#diagnostic" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">2. Diagnostic</a>

--- a/index.html
+++ b/index.html
@@ -40,6 +40,7 @@
                 <a href="Hadoop_Fundamentals.html" class="nav-link text-slate-600 font-medium">Hadoop Fundamentals</a>
                 <a href="Map_Reduce.html" class="nav-link text-slate-600 font-medium">Map Reduce</a>
                 <a href="NoSQL_Deep_Dive.html" class="nav-link text-slate-600 font-medium">NoSQL Deep Dive</a>
+                <a href="Levels_of_Data_Analytics.html" class="nav-link text-slate-600 font-medium">Levels of Data Analytics</a>
             </div>
             <button id="mobile-menu-button" class="md:hidden text-slate-600">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
@@ -51,6 +52,7 @@
             <a href="Hadoop_Fundamentals.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Hadoop Fundamentals</a>
             <a href="Map_Reduce.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Map Reduce</a>
             <a href="NoSQL_Deep_Dive.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">NoSQL Deep Dive</a>
+            <a href="Levels_of_Data_Analytics.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Levels of Data Analytics</a>
         </div>
     </header>
 
@@ -78,6 +80,10 @@
             <a href="NoSQL_Deep_Dive.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">NoSQL Deep Dive</h3>
                 <p class="text-slate-600">Get an in-depth look at non-relational databases, designed for handling large volumes of unstructured data.</p>
+            </a>
+            <a href="Levels_of_Data_Analytics.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Levels of Data Analytics</h3>
+                <p class="text-slate-600">Explore the progression from descriptive to prescriptive analytics.</p>
             </a>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- Link new Levels of Data Analytics page from home navigation and card grid.
- Add Home navigation to Levels_of_Data_Analytics and Hadoop_Fundamentals pages for easier return to the index.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689d8fd842488325bb0d4f1f0aadd73f