### PR TITLE
Relocate practice quiz link and add menu access

### DIFF
--- a/Levels_of_Data_Analytics.html
+++ b/Levels_of_Data_Analytics.html
@@ -82,6 +82,7 @@
                 <a href="#prescriptive" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">4. Prescriptive</a>
                 <a href="#comparison" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">Comparison</a>
                 <a href="#ecosystem" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">Ecosystem</a>
+                <a href="Levels_of_Data_Analytics_Practice_Questions.html" class="nav-link px-4 py-2 rounded-md text-gray-700 hover:bg-[#eaddd7]">Practice Quiz</a>
             </nav>
         </aside>
 
@@ -92,7 +93,6 @@
                     <h2 class="text-4xl font-bold text-[#63534d] mb-4">The Four Levels of Data Analytics</h2>
                     <p class="text-lg text-gray-600 mb-6">This application provides a comprehensive framework for understanding the progressive journey of data-driven decision-making. It explores the four fundamental levels of analytics, from summarizing the past to prescribing future actions. Each level builds upon the last, offering deeper insights and greater strategic value.</p>
                     <p class="text-gray-500 mb-6">Use the navigation on the left or scroll to explore each level of analysis. Interactive elements will help you compare concepts, understand methodologies, and see real-world examples.</p>
-                    <div class="text-center"><a href="Levels_of_Data_Analytics_Practice_Questions.html" class="inline-block mt-4 bg-[#8c7b72] text-white font-medium px-6 py-3 rounded-md hover:bg-[#6f5f57]">Practice Quiz</a></div>
                 </div>
             </section>
 
@@ -129,6 +129,10 @@
                     </div>
                 </div>
             </section>
+
+            <div class="text-center mb-16">
+                <a href="Levels_of_Data_Analytics_Practice_Questions.html" class="inline-block mt-4 bg-[#8c7b72] text-white font-medium px-6 py-3 rounded-md hover:bg-[#6f5f57]">Practice Quiz</a>
+            </div>
 
         </main>
     </div>


### PR DESCRIPTION
## Summary
- Move practice quiz link from introduction to bottom of the Levels of Data Analytics page.
- Add Practice Quiz entry to page navigation menu for easier access.

## Testing
- `npx htmlhint Levels_of_Data_Analytics.html` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_689da7ddc9a88325a70b604f2c706bc4