### PR TITLE
feat: integrate new tools and pages into landing

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,12 @@
                 <a href="Big_Data_Processing.html" class="nav-link text-slate-600 font-medium">Big Data Processing</a>
                 <a href="Big_Data_Storage_Concepts.html" class="nav-link text-slate-600 font-medium">Big Data Storage</a>
                 <a href="Hadoop_Fundamentals.html" class="nav-link text-slate-600 font-medium">Hadoop Fundamentals</a>
+                <a href="Hadoop_Ecosystem.html" class="nav-link text-slate-600 font-medium">Hadoop Ecosystem</a>
                 <a href="Map_Reduce.html" class="nav-link text-slate-600 font-medium">Map Reduce</a>
+                <a href="Apache_Spark.html" class="nav-link text-slate-600 font-medium">Apache Spark</a>
                 <a href="NoSQL_Deep_Dive.html" class="nav-link text-slate-600 font-medium">NoSQL Deep Dive</a>
                 <a href="Levels_of_Data_Analytics.html" class="nav-link text-slate-600 font-medium">Levels of Data Analytics</a>
+                <a href="#tools" class="nav-link text-slate-600 font-medium">Tools</a>
             </div>
             <button id="mobile-menu-button" class="md:hidden text-slate-600">
                 <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
@@ -50,9 +53,12 @@
             <a href="Big_Data_Processing.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Big Data Processing</a>
             <a href="Big_Data_Storage_Concepts.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Big Data Storage</a>
             <a href="Hadoop_Fundamentals.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Hadoop Fundamentals</a>
+            <a href="Hadoop_Ecosystem.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Hadoop Ecosystem</a>
             <a href="Map_Reduce.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Map Reduce</a>
+            <a href="Apache_Spark.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Apache Spark</a>
             <a href="NoSQL_Deep_Dive.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">NoSQL Deep Dive</a>
             <a href="Levels_of_Data_Analytics.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Levels of Data Analytics</a>
+            <a href="#tools" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Tools</a>
         </div>
     </header>
 
@@ -60,7 +66,7 @@
         <h2 class="text-4xl md:text-5xl font-bold text-slate-800 mb-8">Welcome to Your Big Data Resources</h2>
         <p class="text-lg md:text-xl text-slate-600 max-w-3xl mx-auto mb-12">Use the navigation bar above or click on the cards below to explore various aspects of Big Data processing and management concepts.</p>
 
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 gap-8 max-w-4xl mx-auto">
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
             <a href="Big_Data_Processing.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">Big Data Processing</h3>
                 <p class="text-slate-600">Dive into how large datasets are processed and analyzed.</p>
@@ -73,9 +79,17 @@
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">Hadoop Fundamentals</h3>
                 <p class="text-slate-600">Learn the basics of the Hadoop ecosystem and its key components.</p>
             </a>
+            <a href="Hadoop_Ecosystem.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Hadoop Ecosystem</h3>
+                <p class="text-slate-600">Explore an interactive guide to the broader Hadoop ecosystem.</p>
+            </a>
             <a href="Map_Reduce.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">Map Reduce</h3>
                 <p class="text-slate-600">Explore the core programming model for processing large data sets with a parallel, distributed algorithm.</p>
+            </a>
+            <a href="Apache_Spark.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Apache Spark</h3>
+                <p class="text-slate-600">Discover the unified analytics engine for large-scale data processing.</p>
             </a>
             <a href="NoSQL_Deep_Dive.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">NoSQL Deep Dive</h3>
@@ -84,6 +98,22 @@
             <a href="Levels_of_Data_Analytics.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">Levels of Data Analytics</h3>
                 <p class="text-slate-600">Explore the progression from descriptive to prescriptive analytics.</p>
+            </a>
+        </div>
+
+        <h3 id="tools" class="text-3xl font-bold text-slate-800 mt-16 mb-8">Interactive Tools</h3>
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 max-w-6xl mx-auto">
+            <a href="Hadoop_Infrastructure_Estimator.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Hadoop Infrastructure Estimator</h3>
+                <p class="text-slate-600">Estimate cluster requirements for your Hadoop deployments.</p>
+            </a>
+            <a href="record_size_estimator.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Record Size Estimator</h3>
+                <p class="text-slate-600">Calculate record sizes to plan storage efficiently.</p>
+            </a>
+            <a href="Map_Reduce_Visual_Simulator.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">MapReduce Visual Simulator</h3>
+                <p class="text-slate-600">Visualize the MapReduce workflow step by step.</p>
             </a>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- link new Apache Spark and Hadoop Ecosystem pages from the navigation and landing cards
- add an interactive tools section with Hadoop infrastructure estimator, record size estimator, and MapReduce simulator

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aff939e0fc8325bc73f335964a6f3d