### PR TITLE
Add Cassandra page links to NoSQL site

### DIFF
--- a/Apache_Cassandra.html
+++ b/Apache_Cassandra.html
@@ -78,10 +78,14 @@
         <div class="container mx-auto flex justify-between items-center">
             <a href="#overview" class="text-2xl font-bold text-sky-400">Cassandra Guide</a>
             <nav id="top-nav" class="hidden md:flex space-x-6">
+                <a href="index.html" class="nav-link text-lg p-3 rounded-md hover:text-sky-300">Home</a>
+                <a href="NoSQL_Deep_Dive.html" class="nav-link text-lg p-3 rounded-md hover:text-sky-300">NoSQL</a>
             </nav>
             <button id="mobile-menu-btn" class="md:hidden text-sky-400 text-2xl">☰</button>
         </div>
         <nav id="mobile-nav" class="hidden md:hidden absolute top-full left-0 right-0 bg-slate-800 shadow-md flex flex-col items-center py-4 space-y-2">
+            <a href="index.html" class="nav-link text-lg p-3 rounded-md hover:text-sky-300">Home</a>
+            <a href="NoSQL_Deep_Dive.html" class="nav-link text-lg p-3 rounded-md hover:text-sky-300">NoSQL Page</a>
         </nav>
     </header>
 

--- a/NoSQL_Deep_Dive.html
+++ b/NoSQL_Deep_Dive.html
@@ -74,6 +74,7 @@
                 <a href="#future" class="nav-link font-medium pb-1">Future</a>
                 <a href="#products" class="nav-link font-medium pb-1">Products</a>
                 <a href="MongoDB.html" class="nav-link font-medium pb-1">MongoDB</a>
+                <a href="Apache_Cassandra.html" class="nav-link font-medium pb-1">Cassandra</a>
             </div>
             <div class="md:hidden flex items-center space-x-4">
                 <a href="index.html" class="text-slate-600 font-medium">Home</a>
@@ -85,6 +86,7 @@
                     <option value="#future">Future</option>
                     <option value="#products">Products</option>
                     <option value="MongoDB.html">MongoDB</option>
+                    <option value="Apache_Cassandra.html">Cassandra</option>
                 </select>
             </div>
         </nav>


### PR DESCRIPTION
## Summary
- Link Apache Cassandra guide from the NoSQL Deep Dive navigation and mobile menu
- Add Home and NoSQL links to the Cassandra guide for consistent cross-navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b277b73ce08325880fd37166a8bc07