### PR TITLE
Add navigation for Hadoop setup and business value modeler pages

### DIFF
--- a/Business_Value_Modeler.html
+++ b/Business_Value_Modeler.html
@@ -76,16 +76,27 @@
     .btn{ background:#0a0f1a; color:var(--text); border:1px solid rgba(255,255,255,.08); padding:10px 12px; border-radius:10px; cursor:pointer; }
     .btn:hover{ border-color: var(--accent-2); }
 
-    footer{ margin: 14px 0 24px; color: var(--muted); font-size:12px; text-align:center; }
+    .top-nav, .site-footer{ background:#1e293b; color:#e5e7eb; }
+    .top-nav .container{ max-width:1200px; margin:0 auto; padding:12px 24px; display:flex; justify-content:space-between; align-items:center; }
+    .top-nav a{ color:#e5e7eb; text-decoration:none; font-weight:500; }
+    .top-nav a:hover{ color:#22d3ee; }
+    .site-footer .container{ max-width:1200px; margin:0 auto; padding:24px; text-align:center; }
+
     .muted{ color: var(--muted); }
     .mono{ font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; }
     .tip{ font-size:12px; color: var(--muted); margin-top:8px; }
-
+  
     /* Small info chip */
     .chip{ background:rgba(34,211,238,.12); color:#bff5ff; border:1px solid rgba(34,211,238,.3); padding:2px 8px; border-radius:999px; font-size:11px; }
   </style>
 </head>
 <body>
+  <div class="top-nav">
+    <div class="container">
+      <a href="index.html" class="title">Big Data Concepts</a>
+      <a href="index.html">Home</a>
+    </div>
+  </div>
   <div class="wrap">
     <header>
       <div>
@@ -228,11 +239,13 @@
         <p>To add more industries (e.g., <em>Churn prediction</em>, <em>Demand forecasting</em>, <em>Predictive maintenance</em>), duplicate a section and plug in a compute function following the patterns in <span class="mono">updateEcom()</span> / <span class="mono">updateFraud()</span>.</p>
       </div>
     </section>
-
-    <footer>
-      Built with vanilla HTML/CSS/JS/SVG. No external dependencies. © You.
-    </footer>
   </div>
+  <footer class="site-footer">
+    <div class="container">
+      <p>&copy; 2025 Big Data Navigation. Licensed under the <a href="LICENSE">MIT License</a>.</p>
+      <p class="muted">Built with vanilla HTML/CSS/JS/SVG. No external dependencies.</p>
+    </div>
+  </footer>
 
   <script>
     // ---------- Utilities ----------

--- a/Hadoop_Cluster_Setup.html
+++ b/Hadoop_Cluster_Setup.html
@@ -35,6 +35,31 @@
     </style>
 </head>
 <body>
+    <header class="bg-white/80 backdrop-blur-md shadow-sm sticky top-0 z-50">
+        <nav class="container mx-auto px-6 py-4 flex justify-between items-center">
+            <h1 class="text-2xl font-bold text-slate-800">Hadoop Cluster Setup</h1>
+            <div class="hidden md:flex space-x-8">
+                <a href="index.html" class="nav-link text-slate-600 font-medium">Home</a>
+                <a href="#prerequisites" class="nav-link text-slate-600 font-medium">Prerequisites</a>
+                <a href="#installation" class="nav-link text-slate-600 font-medium">Installation</a>
+                <a href="#configuration" class="nav-link text-slate-600 font-medium">Configuration</a>
+                <a href="#daemon-management" class="nav-link text-slate-600 font-medium">Daemons</a>
+                <a href="#test-job" class="nav-link text-slate-600 font-medium">Test Jobs</a>
+            </div>
+            <button id="mobile-menu-button" class="md:hidden text-slate-600">
+                <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7"></path></svg>
+            </button>
+        </nav>
+        <div id="mobile-menu" class="hidden md:hidden">
+            <a href="index.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Home</a>
+            <a href="#prerequisites" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Prerequisites</a>
+            <a href="#installation" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Installation</a>
+            <a href="#configuration" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Configuration</a>
+            <a href="#daemon-management" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Daemons</a>
+            <a href="#test-job" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Test Jobs</a>
+        </div>
+    </header>
+
     <div class="flex flex-col md:flex-row">
         <!-- Sidebar Navigation -->
         <nav class="md:w-1/4 lg:w-1/5 bg-gray-100 p-6 md:sticky top-0 h-screen overflow-y-auto hidden md:block">
@@ -254,6 +279,11 @@
             </section>
         </main>
     </div>
+    <footer class="bg-slate-800 text-white mt-20">
+        <div class="container mx-auto px-6 py-8 text-center">
+            <p>&copy; 2025 Big Data Navigation. Licensed under the <a href="LICENSE">MIT License</a>.</p>
+        </div>
+    </footer>
 
     <script>
         const navLinks = document.querySelectorAll('.nav-link');
@@ -278,6 +308,12 @@
 
         window.addEventListener('scroll', updateActiveLink);
         window.addEventListener('load', updateActiveLink);
+
+        const mobileMenuButton = document.getElementById('mobile-menu-button');
+        const mobileMenu = document.getElementById('mobile-menu');
+        mobileMenuButton.addEventListener('click', () => {
+            mobileMenu.classList.toggle('hidden');
+        });
 
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -43,6 +43,8 @@
                 <a href="Apache_Spark.html" class="nav-link text-slate-600 font-medium">Apache Spark</a>
                 <a href="NoSQL_Deep_Dive.html" class="nav-link text-slate-600 font-medium">NoSQL Deep Dive</a>
                 <a href="Levels_of_Data_Analytics.html" class="nav-link text-slate-600 font-medium">Levels of Data Analytics</a>
+                <a href="Hadoop_Cluster_Setup.html" class="nav-link text-slate-600 font-medium">Hadoop Setup</a>
+                <a href="Business_Value_Modeler.html" class="nav-link text-slate-600 font-medium">Business Value Modeler</a>
                 <a href="#tools" class="nav-link text-slate-600 font-medium">Tools</a>
             </div>
             <button id="mobile-menu-button" class="md:hidden text-slate-600">
@@ -58,6 +60,8 @@
             <a href="Apache_Spark.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Apache Spark</a>
             <a href="NoSQL_Deep_Dive.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">NoSQL Deep Dive</a>
             <a href="Levels_of_Data_Analytics.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Levels of Data Analytics</a>
+            <a href="Hadoop_Cluster_Setup.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Hadoop Setup</a>
+            <a href="Business_Value_Modeler.html" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Business Value Modeler</a>
             <a href="#tools" class="block py-2 px-4 text-sm text-slate-600 hover:bg-slate-100">Tools</a>
         </div>
     </header>
@@ -99,6 +103,10 @@
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">Levels of Data Analytics</h3>
                 <p class="text-slate-600">Explore the progression from descriptive to prescriptive analytics.</p>
             </a>
+            <a href="Hadoop_Cluster_Setup.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Hadoop Cluster Setup</h3>
+                <p class="text-slate-600">Step-by-step guide to building a multi-node Hadoop cluster.</p>
+            </a>
         </div>
 
         <h3 id="tools" class="text-3xl font-bold text-slate-800 mt-16 mb-8">Interactive Tools</h3>
@@ -114,6 +122,10 @@
             <a href="Map_Reduce_Visual_Simulator.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">MapReduce Visual Simulator</h3>
                 <p class="text-slate-600">Visualize the MapReduce workflow step by step.</p>
+            </a>
+            <a href="Business_Value_Modeler.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Business Value Modeler</h3>
+                <p class="text-slate-600">Model ROI and payback for data initiatives.</p>
             </a>
         </div>
     </main>


### PR DESCRIPTION
## Summary
- integrate Hadoop Cluster Setup and Business Value Modeler pages into site navigation and index
- add uniform header and footer to Hadoop cluster setup guide
- add minimal navigation header and MIT license footer to Business Value Modeler

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5acc538348325aab93effe10d92e2