### PR TITLE
Add Home navigation links to child pages

### DIFF
--- a/Apache_Spark.html
+++ b/Apache_Spark.html
@@ -78,6 +78,7 @@
                 <span class="text-sky-600">Apache</span> Spark
             </h1>
             <div class="hidden md:flex space-x-8">
+                <a href="index.html" class="nav-link text-slate-600 font-medium pb-1">Home</a>
                 <a href="#genesis" class="nav-link text-slate-600 font-medium pb-1">Genesis</a>
                 <a href="#architecture" class="nav-link text-slate-600 font-medium pb-1">Architecture</a>
                 <a href="#ecosystem" class="nav-link text-slate-600 font-medium pb-1">Ecosystem</a>

--- a/Hadoop_Ecosystem.html
+++ b/Hadoop_Ecosystem.html
@@ -80,6 +80,9 @@
                 <p class="text-sm text-slate-500 mt-1">An Interactive Guide</p>
             </div>
             <nav class="mt-4">
+                <a href="index.html" class="nav-link block py-3 px-6 text-slate-700 font-medium">
+                    <span class="mr-2">🏠</span> Home
+                </a>
                 <a href="#overview" class="nav-link block py-3 px-6 text-slate-700 font-medium">
                     <span class="mr-2">🚀</span> Overview
                 </a>
@@ -113,6 +116,7 @@
                 </button>
             </div>
             <nav id="mobile-menu" class="hidden">
+                 <a href="index.html" class="nav-link block py-3 px-6 text-slate-700 font-medium">🏠 Home</a>
                  <a href="#overview" class="nav-link block py-3 px-6 text-slate-700 font-medium">🚀 Overview</a>
                  <a href="#history" class="nav-link block py-3 px-6 text-slate-700 font-medium">📜 History Timeline</a>
                  <a href="#architecture" class="nav-link block py-3 px-6 text-slate-700 font-medium">🏗️ Core Architecture</a>

--- a/Hadoop_Infrastructure_Estimator.html
+++ b/Hadoop_Infrastructure_Estimator.html
@@ -85,6 +85,7 @@
     <div class="shell flex" style="justify-content:space-between;">
       <h1><span class="badge">Hadoop</span> Infrastructure Estimator</h1>
       <div class="buttons">
+        <button onclick="window.location.href='index.html'" class="ghost">Home</button>
         <select id="presets">
           <option value="custom">Preset: Custom</option>
           <option value="poc">Preset: Small POC</option>

--- a/Levels_of_Data_Analytics_Practice_Questions.html
+++ b/Levels_of_Data_Analytics_Practice_Questions.html
@@ -95,6 +95,9 @@
 </head>
 <body>
     <div class="quiz-container">
+        <div class="mb-4 text-left">
+            <a href="index.html" class="nav-btn">Home</a>
+        </div>
         <h1 class="text-3xl font-bold quiz-header">Data Analytics Levels Quiz</h1>
         <div id="quiz-content">
             <!-- Questions will be loaded here by JavaScript -->

--- a/Map_Reduce_Visual_Simulator.html
+++ b/Map_Reduce_Visual_Simulator.html
@@ -112,6 +112,7 @@
         <div class="title">MapReduce Visual Simulator</div>
         <div class="subtitle">Dataset: Monthly Regional Sales • 6 Data Nodes • Visualize each phase → Input ➝ Map ➝ Combine ➝ Shuffle/Sort ➝ Reduce ➝ Top‑3</div>
       </div>
+      <a href="index.html" class="btn">Home</a>
     </header>
 
     <section class="controls">

--- a/mongodb-flashcards.html
+++ b/mongodb-flashcards.html
@@ -149,6 +149,7 @@
         <div class="sub">Pick a category → choose Flashcards or Quiz → draw 5 → practice</div>
       </div>
     </div>
+    <a href="index.html" class="btn secondary">Home</a>
   </header>
 
   <div class="container">

--- a/record_size_estimator.html
+++ b/record_size_estimator.html
@@ -53,6 +53,7 @@
     <div class="shell flex" style="justify-content:space-between; align-items:center;">
       <h1><span class="badge">Data</span> Record Size Estimator</h1>
       <div class="buttons">
+        <button onclick="window.location.href='index.html'" class="ghost">Home</button>
         <!-- future buttons if needed -->
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Add Home button pointing to index page across child pages
- Ensure easier navigation back to homepage from Apache Spark, Hadoop Ecosystem, Hadoop Infrastructure Estimator, Levels of Data Analytics Practice Questions, Map Reduce Visual Simulator, MongoDB flashcards, and Record Size Estimator

## Testing
- `npm test` *(fails: ENOENT, package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baceb6fe008325b5652c5f20459560