### PR TITLE
Add Apache Hive page with navigation and licensing

### DIFF
--- a/Apache_Hive.html
+++ b/Apache_Hive.html
@@ -79,6 +79,7 @@
                 </div>
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-4">
+                        <a href="index.html" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Home</a>
                         <a href="#introduction" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Introduction</a>
                         <a href="#architecture" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Architecture</a>
                         <a href="#deepdive" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Technical Deep Dive</a>
@@ -97,6 +98,7 @@
         </nav>
         <div id="mobile-menu" class="md:hidden hidden">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+                <a href="index.html" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Home</a>
                 <a href="#introduction" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Introduction</a>
                 <a href="#architecture" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Architecture</a>
                 <a href="#deepdive" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Technical Deep Dive</a>
@@ -289,6 +291,7 @@ LIMIT 10;</code></pre>
         <div class="container mx-auto py-6 px-4 sm:px-6 lg:px-8 text-center">
             <p>Interactive Report generated on <span id="generationDate"></span>.</p>
             <p class="text-sm text-gray-400 mt-1">This is a conceptual, interactive web application designed for educational purposes.</p>
+            <p class="text-sm mt-2">&copy; 2025 Big Data Concepts. Licensed under the <a href="LICENSE" class="underline">MIT License</a>.</p>
         </div>
     </footer>
 

--- a/index.html
+++ b/index.html
@@ -85,6 +85,10 @@
                     <h3 class="text-2xl font-bold text-amber-500 mb-2">Hadoop Ecosystem</h3>
                     <p class="text-slate-600">Explore an interactive guide to the broader Hadoop ecosystem.</p>
                 </a>
+                <a href="Apache_Hive.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                    <h3 class="text-2xl font-bold text-amber-500 mb-2">Apache Hive</h3>
+                    <p class="text-slate-600">Use SQL-like queries to analyze large datasets stored in Hadoop.</p>
+                </a>
                 <a href="Map_Reduce.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                     <h3 class="text-2xl font-bold text-amber-500 mb-2">Map Reduce</h3>
                     <p class="text-slate-600">Explore the core programming model for processing large data sets with a parallel, distributed algorithm.</p>


### PR DESCRIPTION
## Summary
- Link Apache Hive content from the home page
- Add Home navigation and MIT license notice to Apache Hive page

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_68bea88f635483258fb6659321a4435b