### PR TITLE
Integrate Apache Pig into site navigation

### DIFF
--- a/Apache_Pig.html
+++ b/Apache_Pig.html
@@ -84,6 +84,7 @@
                 </div>
                 <div class="hidden md:block">
                     <div class="ml-10 flex items-baseline space-x-4">
+                        <a href="index.html" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Home</a>
                         <a href="#introduction" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Introduction</a>
                         <a href="#anatomy" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Anatomy</a>
                         <a href="#piglatin" class="nav-link px-3 py-2 rounded-md text-sm font-medium text-gray-700">Pig Latin</a>
@@ -102,6 +103,7 @@
         </nav>
         <div id="mobile-menu" class="md:hidden hidden">
             <div class="px-2 pt-2 pb-3 space-y-1 sm:px-3">
+                <a href="index.html" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Home</a>
                 <a href="#introduction" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Introduction</a>
                 <a href="#anatomy" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Anatomy</a>
                 <a href="#piglatin" class="block nav-link px-3 py-2 rounded-md text-base font-medium text-gray-700">Pig Latin</a>

--- a/index.html
+++ b/index.html
@@ -89,6 +89,10 @@
                     <h3 class="text-2xl font-bold text-amber-500 mb-2">Apache Hive</h3>
                     <p class="text-slate-600">Use SQL-like queries to analyze large datasets stored in Hadoop.</p>
                 </a>
+                <a href="Apache_Pig.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                    <h3 class="text-2xl font-bold text-amber-500 mb-2">Apache Pig</h3>
+                    <p class="text-slate-600">Simplify MapReduce jobs with a high-level data flow language.</p>
+                </a>
                 <a href="Map_Reduce.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
                     <h3 class="text-2xl font-bold text-amber-500 mb-2">Map Reduce</h3>
                     <p class="text-slate-600">Explore the core programming model for processing large data sets with a parallel, distributed algorithm.</p>


### PR DESCRIPTION
## Summary
- Link Apache Pig page in Hadoop Ecosystem section on the homepage
- Add Home navigation to Apache Pig page for both desktop and mobile views

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bffb1918708325ba2692afcbcf54b0