### PR TITLE
Add Hadoop simulation tool and navigation link

### DIFF
--- a/Hadoop_Simulation_New.html
+++ b/Hadoop_Simulation_New.html
@@ -79,6 +79,7 @@
       <h1>Retail/E‑Commerce: Hadoop‑based Product Recommendations — Visual Simulation</h1>
       <div class="sub">Click <span class="kbd">Next</span> to progress step‑by‑step from data generation → ingestion → storage → transformation → model training → serving. Uses only HTML, CSS, JavaScript, and SVG.</div>
       <div class="controls">
+        <button id="homeBtn" class="ghost" onclick="window.location.href='index.html'">Home</button>
         <button id="prevBtn" class="ghost">◀︎ Back</button>
         <button id="nextBtn" class="primary">Next ▶︎</button>
         <button id="resetBtn">Reset</button>

--- a/index.html
+++ b/index.html
@@ -136,6 +136,10 @@
                 <h3 class="text-2xl font-bold text-amber-500 mb-2">Business Value Modeler</h3>
                 <p class="text-slate-600">Model ROI and payback for data initiatives.</p>
             </a>
+            <a href="Hadoop_Simulation_New.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                <h3 class="text-2xl font-bold text-amber-500 mb-2">Hadoop Simulation</h3>
+                <p class="text-slate-600">Step through an e-commerce recommender built on Hadoop.</p>
+            </a>
         </div>
     </main>
 


### PR DESCRIPTION
## Summary
- Link new Hadoop Simulation tool from the Interactive Tools section
- Add Home button to Hadoop Simulation for easy navigation

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c37d25826083258d2d1a979ebb7136