### PR TITLE
Integrate data format explorer and refresh styling

### DIFF
--- a/2025_Data_Format_Report.html
+++ b/2025_Data_Format_Report.html
@@ -16,8 +16,8 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #0f172a;
-            color: #e2e8f0;
+            background-color: #f8fafc;
+            color: #334155;
         }
         .container {
             max-width: 1280px;
@@ -26,38 +26,52 @@
             padding: 1rem 2rem;
         }
         .glass-pane {
-            background-color: rgba(17, 24, 39, 0.8);
+            background-color: rgba(255, 255, 255, 0.92);
             backdrop-filter: blur(12px);
-            border: 1px solid rgba(55, 65, 81, 0.5);
+            border: 1px solid rgba(226, 232, 240, 0.9);
+            box-shadow: 0 16px 32px rgba(15, 23, 42, 0.08);
         }
         .tag {
             display: inline-block;
             font-size: 0.75rem;
-            font-weight: 500;
+            font-weight: 600;
             padding: 0.25rem 0.75rem;
             border-radius: 9999px;
             text-transform: uppercase;
+            letter-spacing: 0.04em;
         }
         .details-list li {
             position: relative;
             padding-left: 1.25rem;
             margin-bottom: 0.5rem;
+            color: #475569;
         }
         .details-list li::before {
             content: '✓';
             position: absolute;
             left: 0;
-            color: #22d3ee;
+            color: #f59e0b;
+            font-weight: 700;
         }
         select, input {
             -webkit-appearance: none;
             -moz-appearance: none;
             appearance: none;
-            background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%236b7280' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
-            background-position: right 0.5rem center;
+            background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' fill='none' viewBox='0 0 20 20'%3e%3cpath stroke='%2394a3b8' stroke-linecap='round' stroke-linejoin='round' stroke-width='1.5' d='M6 8l4 4 4-4'/%3e%3c/svg%3e");
+            background-position: right 0.75rem center;
             background-repeat: no-repeat;
-            background-size: 1.5em 1.5em;
+            background-size: 1.25em 1.25em;
             padding-right: 2.5rem;
+            background-color: #ffffff;
+            border: 1px solid #cbd5f5;
+            border-radius: 0.75rem;
+            color: #1e293b;
+        }
+        select:focus,
+        input:focus {
+            outline: none;
+            border-color: #f59e0b;
+            box-shadow: 0 0 0 3px rgba(245, 158, 11, 0.25);
         }
         .chart-container {
             position: relative;
@@ -68,52 +82,60 @@
 </head>
 <body class="antialiased">
 
-    <header class="py-4 sticky top-0 z-50 glass-pane">
-        <div class="container flex justify-between items-center">
-            <h1 class="text-2xl font-bold text-white">The 2025 Data Format Report</h1>
-            <p class="text-sm text-slate-400 hidden sm:block">An Interactive Guide to Established & Emerging Standards</p>
+    <header class="sticky top-0 z-50 bg-white/90 backdrop-blur-md border-b border-slate-200 shadow-sm">
+        <div class="container flex flex-col gap-4 py-4 md:flex-row md:items-center md:justify-between">
+            <div>
+                <div class="flex flex-wrap items-center gap-3 text-sm font-semibold text-amber-600">
+                    <a href="index.html" class="transition-colors hover:text-amber-700">&larr; Back to main navigation</a>
+                    <span class="hidden md:inline text-slate-300">•</span>
+                    <a href="Big_Data_Formats.html" class="text-slate-500 transition-colors hover:text-amber-700">Formats explorer</a>
+                </div>
+                <h1 class="mt-2 text-3xl font-bold text-slate-900 sm:text-4xl">The 2025 Data Format Report</h1>
+                <p class="mt-2 text-sm text-slate-500 sm:text-base">An interactive guide to established and emerging standards.</p>
+            </div>
+            <a href="#explorer" class="inline-flex items-center justify-center rounded-lg bg-amber-500 px-4 py-2 font-semibold text-white shadow-sm transition-colors hover:bg-amber-600">Jump to explorer</a>
         </div>
     </header>
 
     <main class="container">
         
         <section id="intro" class="text-center my-12">
-            <h2 class="text-4xl font-bold tracking-tight text-white sm:text-5xl">The Unseen Engines of Data</h2>
-            <p class="mt-6 text-lg leading-8 text-slate-300">From web APIs to peta-scale analytics and generative AI, data formats are the fundamental building blocks of the digital world. This guide provides an interactive overview of the most critical formats in use today and a look at what's coming next.</p>
+            <h2 class="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl">The Unseen Engines of Data</h2>
+            <p class="mt-6 text-lg leading-8 text-slate-600">From web APIs to peta-scale analytics and generative AI, data formats are the fundamental building blocks of the digital world. This guide provides an interactive overview of the most critical formats in use today and a look at what's coming next.</p>
         </section>
 
         <section id="trends" class="my-16">
-            <h3 class="text-2xl font-bold text-center text-white mb-8">Key Trends Shaping the Future of Formats</h3>
+            <h3 class="text-2xl font-bold text-center text-slate-900 mb-8">Key Trends Shaping the Future of Formats</h3>
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
                 <div class="p-6 rounded-xl glass-pane">
-                    <h4 class="font-semibold text-cyan-400">The Lakehouse Paradigm</h4>
-                    <p class="text-sm text-slate-400 mt-2">Table formats like Delta Lake, Iceberg, and Hudi are bringing database capabilities (ACID transactions, time travel) directly to data lakes, unifying streaming and batch processing on open formats like Parquet.</p>
+                    <h4 class="font-semibold text-amber-600">The Lakehouse Paradigm</h4>
+                    <p class="text-sm text-slate-600 mt-2">Table formats like Delta Lake, Iceberg, and Hudi are bringing database capabilities (ACID transactions, time travel) directly to data lakes, unifying streaming and batch processing on open formats like Parquet.</p>
                 </div>
                 <div class="p-6 rounded-xl glass-pane">
-                    <h4 class="font-semibold text-cyan-400">AI & Vector-Specific Formats</h4>
-                    <p class="text-sm text-slate-400 mt-2">The rise of Generative AI has created a need for formats optimized for vector embeddings and multi-modal data. Formats like Lance are emerging to enable efficient similarity search and ML training at scale.</p>
+                    <h4 class="font-semibold text-amber-600">AI & Vector-Specific Formats</h4>
+                    <p class="text-sm text-slate-600 mt-2">The rise of Generative AI has created a need for formats optimized for vector embeddings and multi-modal data. Formats like Lance are emerging to enable efficient similarity search and ML training at scale.</p>
                 </div>
                 <div class="p-6 rounded-xl glass-pane">
-                    <h4 class="font-semibold text-cyan-400">Cloud-Native Architecture</h4>
-                    <p class="text-sm text-slate-400 mt-2">Formats are increasingly designed for object storage (like S3). This means supporting partial reads and parallel access, with formats like Zarr and Cloud-Optimized GeoTIFFs leading the way for large-scale scientific data.</p>
+                    <h4 class="font-semibold text-amber-600">Cloud-Native Architecture</h4>
+                    <p class="text-sm text-slate-600 mt-2">Formats are increasingly designed for object storage (like S3). This means supporting partial reads and parallel access, with formats like Zarr and Cloud-Optimized GeoTIFFs leading the way for large-scale scientific data.</p>
                 </div>
                 <div class="p-6 rounded-xl glass-pane">
-                    <h4 class="font-semibold text-cyan-400">Interoperability via Arrow</h4>
-                    <p class="text-sm text-slate-400 mt-2">Apache Arrow's in-memory columnar format is becoming the de-facto standard for zero-copy data exchange between different systems (Spark, Pandas, databases), dramatically speeding up data pipelines.</p>
+                    <h4 class="font-semibold text-amber-600">Interoperability via Arrow</h4>
+                    <p class="text-sm text-slate-600 mt-2">Apache Arrow's in-memory columnar format is becoming the de-facto standard for zero-copy data exchange between different systems (Spark, Pandas, databases), dramatically speeding up data pipelines.</p>
                 </div>
             </div>
         </section>
 
         <section id="explorer" class="my-16">
-            <div class="glass-pane p-4 sm:p-6 rounded-xl sticky top-[73px] z-40">
+            <div class="glass-pane p-4 sm:p-6 rounded-xl sticky top-[88px] z-40">
                 <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-                    <input type="search" id="search-input" placeholder="Search formats..." class="w-full bg-slate-900/50 border border-slate-700 rounded-lg px-4 py-2 text-white focus:ring-2 focus:ring-cyan-500 focus:outline-none">
-                    <select id="status-filter" class="w-full bg-slate-900/50 border border-slate-700 rounded-lg px-4 py-2 text-white focus:ring-2 focus:ring-cyan-500 focus:outline-none">
+                    <input type="search" id="search-input" placeholder="Search formats..." class="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400">
+                    <select id="status-filter" class="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400">
                         <option value="">All Statuses</option>
                         <option value="Established">Established</option>
                         <option value="Emerging">Emerging</option>
                     </select>
-                    <select id="domain-filter" class="w-full bg-slate-900/50 border border-slate-700 rounded-lg px-4 py-2 text-white focus:ring-2 focus:ring-cyan-500 focus:outline-none">
+                    <select id="domain-filter" class="w-full bg-white border border-slate-300 rounded-lg px-4 py-2 text-slate-700 focus:outline-none focus:ring-2 focus:ring-amber-400">
                         <option value="">All Domains</option>
                         <option value="Analytics">Analytics</option>
                         <option value="Streaming">Streaming & Serialization</option>
@@ -123,18 +145,18 @@
                         <option value="Scientific">Scientific & HPC</option>
                         <option value="Geospatial">Geospatial</option>
                     </select>
-                    <button id="reset-filters" class="w-full bg-cyan-600 hover:bg-cyan-700 text-white font-semibold rounded-lg px-4 py-2 transition-colors">Reset</button>
+                    <button id="reset-filters" class="w-full bg-amber-500 hover:bg-amber-600 text-white font-semibold rounded-lg px-4 py-2 transition-colors">Reset</button>
                 </div>
             </div>
 
             <div id="format-grid" class="mt-8 grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
                 <!-- Format cards will be injected here by JavaScript -->
             </div>
-             <p id="no-results" class="text-center text-slate-400 mt-8 text-lg hidden">No formats match your criteria.</p>
+             <p id="no-results" class="text-center text-slate-500 mt-8 text-lg hidden">No formats match your criteria.</p>
         </section>
-        
+
         <section id="timeline" class="my-16">
-            <h3 class="text-2xl font-bold text-center text-white mb-8">Evolution of Data Formats</h3>
+            <h3 class="text-2xl font-bold text-center text-slate-900 mb-8">Evolution of Data Formats</h3>
             <div class="glass-pane p-6 rounded-xl">
                 <div class="chart-container">
                     <canvas id="timeline-chart"></canvas>
@@ -271,22 +293,22 @@ document.addEventListener('DOMContentLoaded', () => {
     const resetBtn = document.getElementById('reset-filters');
     
     const createCard = (format) => {
-        const statusColor = format.status === 'Established' ? 'bg-blue-500/10 text-blue-400 border border-blue-500/20' : 'bg-purple-500/10 text-purple-400 border border-purple-500/20';
-        const domainColor = 'bg-slate-700/50 text-slate-300';
-        
+        const statusColor = format.status === 'Established' ? 'bg-emerald-100 text-emerald-700 border border-emerald-200' : 'bg-violet-100 text-violet-700 border border-violet-200';
+        const domainColor = 'bg-slate-100 text-slate-600 border border-slate-200';
+
         return `
-            <div class="glass-pane rounded-xl p-6 flex flex-col transition-transform duration-300 hover:scale-105">
+            <div class="glass-pane rounded-xl p-6 flex flex-col transition-transform duration-300 hover:-translate-y-1 hover:shadow-lg">
                 <div class="flex justify-between items-start">
-                    <h4 class="text-xl font-bold text-white">${format.name}</h4>
+                    <h4 class="text-xl font-bold text-slate-900">${format.name}</h4>
                     <span class="tag ${statusColor}">${format.status}</span>
                 </div>
-                <p class="text-slate-400 text-sm mt-2 flex-grow">${format.summary}</p>
+                <p class="text-slate-600 text-sm mt-2 flex-grow">${format.summary}</p>
                 <div class="mt-4">
                     <span class="tag ${domainColor}">${format.domain}</span>
                 </div>
-                <div class="mt-6 border-t border-slate-700 pt-4">
-                    <h5 class="text-sm font-semibold text-cyan-400 mb-2">Key Characteristics</h5>
-                    <ul class="text-sm text-slate-400 details-list">
+                <div class="mt-6 border-t border-slate-200 pt-4">
+                    <h5 class="text-sm font-semibold text-amber-600 mb-2">Key Characteristics</h5>
+                    <ul class="text-sm text-slate-600 details-list">
                         ${format.characteristics.map(c => `<li>${c}</li>`).join('')}
                     </ul>
                 </div>
@@ -350,8 +372,8 @@ document.addEventListener('DOMContentLoaded', () => {
             datasets: [{
                 label: 'Data Formats',
                 data: timelineData,
-                backgroundColor: 'rgba(34, 211, 238, 0.8)',
-                borderColor: 'rgb(107, 235, 255)',
+                backgroundColor: 'rgba(245, 158, 11, 0.85)',
+                borderColor: 'rgb(217, 119, 6)',
                 pointRadius: 8,
                 pointHoverRadius: 12,
             }]
@@ -369,11 +391,15 @@ document.addEventListener('DOMContentLoaded', () => {
                         }
                     },
                     displayColors: false,
-                    backgroundColor: '#1e293b',
+                    backgroundColor: '#ffffff',
+                    titleColor: '#0f172a',
+                    bodyColor: '#334155',
                     titleFont: { size: 14, weight: 'bold' },
                     bodyFont: { size: 12 },
                     padding: 10,
                     cornerRadius: 8,
+                    borderColor: '#e2e8f0',
+                    borderWidth: 1,
                 }
             },
             scales: {
@@ -381,7 +407,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     type: 'linear',
                     position: 'bottom',
                     title: { display: true, text: 'Year Introduced', color: '#94a3b8' },
-                    grid: { color: 'rgba(55, 65, 81, 0.5)' },
+                    grid: { color: 'rgba(148, 163, 184, 0.35)' },
                     ticks: { color: '#94a3b8', stepSize: 5, callback: (v) => v },
                     min: 1998,
                     max: 2024

--- a/Big_Data_Formats.html
+++ b/Big_Data_Formats.html
@@ -9,43 +9,119 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 <style>
   :root {
-    --bg: #0f172a;
-    --card: #111827;
-    --muted: #94a3b8;
-    --text: #e5e7eb;
-    --accent: #22d3ee;
-    --accent-lighter: #67e8f9;
-    --accent2: #a78bfa;
-    --border: #1f2937;
-    --good: #22c55e;
-    --warn: #eab308;
+    --bg: #f8fafc;
+    --card: #ffffff;
+    --muted: #64748b;
+    --text: #1e293b;
+    --accent: #f59e0b;
+    --accent-lighter: #fbbf24;
+    --accent2: #6366f1;
+    --border: #e2e8f0;
+    --good: #16a34a;
+    --warn: #f59e0b;
     --bad: #ef4444;
   }
   * { box-sizing: border-box; }
   body {
     margin: 0;
     font-family: 'Inter', sans-serif;
-    background: linear-gradient(180deg, #0b1020, #0f172a);
+    background: var(--bg);
     color: var(--text);
   }
+  a { color: var(--accent); text-decoration: none; }
+  a:hover { color: #d97706; }
   header {
     position: sticky;
     top: 0;
     z-index: 50;
-    backdrop-filter: blur(8px);
-    background: rgba(15,23,42,.8);
+    backdrop-filter: blur(12px);
+    background: rgba(255,255,255,0.9);
     border-bottom: 1px solid var(--border);
+    box-shadow: 0 12px 30px rgba(15,23,42,0.08);
+  }
+  .top-bar {
+    background: #fef3c7;
+    border-bottom: 1px solid #fde68a;
+    padding: 8px 0;
   }
   .container {
     width: min(1200px, 92vw);
     margin: 0 auto;
-    padding: 16px 0 40px 0;
+  }
+  .top-bar .container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .top-bar a {
+    color: #b45309;
+    font-weight: 600;
+    font-size: 14px;
+  }
+  .top-bar a:hover {
+    color: #92400e;
+  }
+  .header-content {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 24px;
+    padding: 20px 0;
+    flex-wrap: wrap;
+  }
+  .header-content h1 {
+    font-size: 2.25rem;
+    margin: 0;
+    color: var(--text);
+  }
+  .subtitle {
+    margin: 6px 0 0;
+    color: var(--muted);
+    max-width: 520px;
+  }
+  .nav-actions {
+    display: flex;
+    gap: 12px;
+    flex-wrap: wrap;
+  }
+  .nav-actions a {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    font-weight: 600;
+    color: #1f2937;
+    font-size: 14px;
+    padding: 8px 12px;
+    border-radius: 10px;
+    border: 1px solid var(--border);
+    background: #ffffff;
+    transition: all 0.2s ease;
+  }
+  .nav-actions a:hover {
+    border-color: var(--accent);
+    box-shadow: 0 12px 28px rgba(245,158,11,0.18);
+    color: #92400e;
+  }
+  .pill {
+    color: #b45309;
+    background: #fef3c7;
+    border: 1px solid #fde68a;
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .page {
+    padding: 32px 0 64px;
   }
   h1, h2, h3 { margin: 0.6em 0 0.4em; }
-  h1 { font-size: 2rem; }
-  h2 { font-size: 1.4rem; color: var(--accent-lighter); }
-  h3 { font-size: 1.1rem; color: var(--accent2); }
-  p { color: var(--muted); line-height: 1.6; }
+  h2 { font-size: 1.6rem; color: #1e293b; }
+  h3 { font-size: 1.2rem; color: #4338ca; }
+  p { color: var(--muted); line-height: 1.65; }
   .grid {
     display: grid;
     gap: 16px;
@@ -53,81 +129,156 @@
   .grid.cols-2 { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
   .grid.cols-3 { grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); }
   .card {
-    background: linear-gradient(180deg, #0f172a, #0b1324);
+    background: var(--card);
     border: 1px solid var(--border);
     border-radius: 16px;
-    padding: 16px 18px;
-    box-shadow: 0 10px 30px rgba(0,0,0,.25);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
+    padding: 20px 22px;
+    box-shadow: 0 12px 28px rgba(15,23,42,0.08);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   }
-  .card:hover, .card.highlight {
-    transform: translateY(-5px);
-    box-shadow: 0 12px 35px rgba(34,211,238,.1);
+  .card:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 22px 40px rgba(15,23,42,0.12);
   }
-  .tag { display: inline-block; font-size: 12px; padding: 4px 8px; margin: 2px 6px 2px 0; border-radius: 999px; border: 1px solid var(--border); color: #cbd5e1;}
-  .tag.good { border-color: #064e3b; background: rgba(34,197,94,.1); color:#bbf7d0 }
-  .tag.warn { border-color: #713f12; background: rgba(234,179,8,.1); color:#fde68a }
-  .tag.bad  { border-color: #7f1d1d; background: rgba(239,68,68,.1); color:#fecaca }
-  .pill { color:var(--accent); background: rgba(34,211,238,.1); border:1px solid #075985; padding:2px 8px; border-radius:999px; font-size:12px; }
-  details { border: 1px dashed var(--border); border-radius: 12px; padding: 10px 12px; margin: 10px 0; }
-  details[open] { background: rgba(167,139,250,.06); border-style: solid; }
-  summary { cursor: pointer; font-weight: 600; color:var(--accent2); }
+  .card.highlight {
+    border-color: var(--accent);
+    box-shadow: 0 18px 36px rgba(245,158,11,0.22);
+  }
+  .tag {
+    display: inline-flex;
+    align-items: center;
+    font-size: 12px;
+    padding: 4px 10px;
+    margin: 2px 6px 2px 0;
+    border-radius: 999px;
+    border: 1px solid var(--border);
+    background: #f1f5f9;
+    color: #475569;
+    font-weight: 500;
+  }
+  .tag.good {
+    border-color: rgba(134,239,172,0.6);
+    background: rgba(187,247,208,0.7);
+    color: #166534;
+  }
+  .tag.warn {
+    border-color: rgba(253,230,138,0.9);
+    background: rgba(254,243,199,0.85);
+    color: #92400e;
+  }
+  .tag.bad {
+    border-color: rgba(254,202,202,0.7);
+    background: rgba(254,226,226,0.85);
+    color: #b91c1c;
+  }
+  details {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px 16px;
+    margin: 12px 0;
+    background: #f8fafc;
+  }
+  details[open] {
+    background: #fff7ed;
+    border-color: #fbbf24;
+  }
+  summary {
+    cursor: pointer;
+    font-weight: 600;
+    color: #b45309;
+  }
   summary:hover { text-decoration: underline; }
   code, pre {
-    background: #0b1020;
-    border: 1px solid var(--border);
+    background: #0f172a;
+    border: 1px solid #1e293b;
     border-radius: 10px;
-    color: #d1fae5;
+    color: #e2e8f0;
   }
-  code { padding: 2px 6px; }
-  pre { padding: 12px; overflow:auto; }
+  code { padding: 2px 6px; display: inline-block; }
+  pre { padding: 12px; overflow: auto; }
   .row { display:flex; align-items:center; gap:12px; flex-wrap: wrap; }
   .toolbar {
-    display:flex; gap:12px; flex-wrap: wrap; align-items: center;
-    padding: 14px; border:1px solid var(--border); border-radius: 14px;
-    background: linear-gradient(180deg, #0b1324, #0a1222);
+    display:flex;
+    gap:12px;
+    flex-wrap: wrap;
+    align-items: center;
+    padding: 16px;
+    border:1px solid var(--border);
+    border-radius: 14px;
+    background: #f1f5f9;
   }
   input[type="search"], select, button {
-    background: #0b1020; color: var(--text); border:1px solid var(--border);
-    padding:10px 12px; border-radius: 10px; outline: none;
-    transition: background-color 0.2s ease, border-color 0.2s ease;
+    background: #ffffff;
+    color: var(--text);
+    border:1px solid var(--border);
+    padding:10px 12px;
+    border-radius: 10px;
+    outline: none;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
   input[type="search"]:focus, select:focus {
     border-color: var(--accent);
+    box-shadow: 0 0 0 3px rgba(245,158,11,0.25);
   }
   .toolbar button {
     cursor: pointer;
-    background: rgba(34,211,238,.1);
-    color: var(--accent);
-    border-color: #075985;
+    background: var(--accent);
+    color: #ffffff;
+    border-color: var(--accent);
+    font-weight: 600;
   }
   .toolbar button:hover {
-    background: rgba(34,211,238,.2);
+    background: #d97706;
+    border-color: #d97706;
   }
   .copy-btn {
-    float: right; margin-left: 8px; padding: 4px 8px; font-size: 12px;
-    background: #0b1324; color: #93c5fd; border:1px solid #1e293b; border-radius: 8px; cursor: pointer;
-    transition: background 0.2s ease, transform 0.2s ease;
+    float: right;
+    margin-left: 8px;
+    padding: 4px 10px;
+    font-size: 12px;
+    background: #f8fafc;
+    color: #334155;
+    border:1px solid var(--border);
+    border-radius: 8px;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
   }
   .copy-btn:hover {
-    background: #111827;
+    background: #e2e8f0;
+    color: #1e293b;
     transform: translateY(-1px);
   }
   table { width: 100%; border-collapse: collapse; }
-  th, td { border-bottom: 1px solid #1e293b; padding: 10px 8px; text-align: left; vertical-align: top; }
-  th {
-    position: sticky; top: 0; background:rgba(13,21,48,.8); backdrop-filter: blur(8px);
-    z-index:1; cursor: pointer;
-    transition: color 0.2s ease;
+  th, td {
+    border-bottom: 1px solid var(--border);
+    padding: 12px 10px;
+    text-align: left;
+    vertical-align: top;
   }
-  th:hover { color: var(--accent-lighter); }
-  .small { font-size: 12px; color:#a1a1aa }
-  .section { margin-top: 28px; }
-  .kbd { border:1px solid #374151; background:#0f172a; padding:2px 6px; border-radius:6px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; color:#93c5fd }
-  footer { color:#64748b; font-size: 12px; margin-top: 40px; text-align:center; }
-  .highlight-row { background-color: rgba(167,139,250,.1); }
-  .concept-card { background: rgba(167,139,250,.06); border: 1px solid #4c2c88; margin-bottom: 16px; }
-  .concept-card h3 { margin-top: 0; color: #d1c1fa; }
+  th {
+    position: sticky;
+    top: 0;
+    background: rgba(248,250,252,0.95);
+    backdrop-filter: blur(6px);
+    z-index:1;
+    cursor: pointer;
+    transition: color 0.2s ease;
+    font-weight: 600;
+    color: #475569;
+  }
+  th:hover { color: var(--accent); }
+  tbody tr:hover { background: #fff7ed; }
+  .small { font-size: 12px; color:#94a3b8; }
+  .section { margin-top: 32px; }
+  .kbd { border:1px solid #cbd5f5; background:#eef2ff; padding:2px 6px; border-radius:6px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; color:#4338ca; }
+  footer { color:#94a3b8; font-size: 12px; margin-top: 40px; text-align:center; }
+  .highlight-row { background-color: rgba(251,191,36,0.2); }
+  .concept-card {
+    background: linear-gradient(135deg, rgba(99,102,241,0.08), rgba(59,130,246,0.05));
+    border: 1px solid rgba(99,102,241,0.25);
+    margin-bottom: 16px;
+  }
+  .concept-card h3 { margin-top: 0; color: #4338ca; }
   .concept-card p { margin-bottom: 0; }
   .flow-diagram-container {
     display: flex;
@@ -136,19 +287,55 @@
     flex-wrap: wrap;
     gap: 20px;
     padding: 20px;
-    background: rgba(167,139,250,.06);
+    background: linear-gradient(135deg, rgba(251,191,36,0.18), rgba(236,233,254,0.8));
     border-radius: 12px;
-    border: 1px solid #4c2c88;
+    border: 1px solid rgba(251,191,36,0.45);
   }
   .flow-step {
     text-align: center;
-    color: var(--accent-lighter);
+    color: #b45309;
     font-weight: 600;
   }
   .flow-arrow {
     font-size: 2rem;
     color: var(--accent2);
     transform: rotate(90deg);
+  }
+  .report-callout {
+    margin-top: 20px;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 16px 18px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(245,158,11,0.15), rgba(99,102,241,0.15));
+    border: 1px solid rgba(245,158,11,0.35);
+  }
+  .report-callout h3 {
+    margin: 0;
+    color: #92400e;
+  }
+  .report-callout p {
+    margin: 4px 0 0;
+    color: #475569;
+  }
+  .cta-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    padding: 10px 16px;
+    border-radius: 10px;
+    background: var(--accent);
+    color: #ffffff;
+    font-weight: 600;
+    text-decoration: none;
+    transition: background 0.2s ease, box-shadow 0.2s ease;
+  }
+  .cta-button:hover {
+    background: #d97706;
+    box-shadow: 0 16px 32px rgba(245,158,11,0.25);
   }
   @media (min-width: 600px) {
     .flow-arrow {
@@ -158,17 +345,41 @@
       flex-wrap: nowrap;
     }
   }
+  @media (max-width: 640px) {
+    .nav-actions {
+      width: 100%;
+    }
+    .nav-actions a {
+      flex: 1 1 100%;
+      justify-content: center;
+    }
+    .header-content {
+      align-items: flex-start;
+    }
+  }
 </style>
 </head>
 <body>
   <header>
-    <div class="container row">
-      <h1 style="flex:1">Big Data Formats — Interactive Guide</h1>
+    <div class="top-bar">
+      <div class="container">
+        <a href="index.html">&larr; Back to main navigation</a>
+        <div class="nav-actions">
+          <a href="#summary">Jump to comparison table</a>
+          <a href="2025_Data_Format_Report.html">View the 2025 Data Format Report</a>
+        </div>
+      </div>
+    </div>
+    <div class="container header-content">
+      <div>
+        <h1>Big Data Formats Explorer</h1>
+        <p class="subtitle">Identify the right file, table, and serialization formats for ingestion, analytics, streaming, and lakehouse workloads.</p>
+      </div>
       <span class="pill">CSV · JSON · XML · Parquet · ORC · Arrow · Avro · Protobuf · Thrift · SequenceFile · TFRecord · HDF5 · NetCDF · Delta · Iceberg · Hudi · Kudu</span>
     </div>
   </header>
 
-  <main class="container">
+  <main class="container page">
     <section class="card">
       <h2>How to use this guide</h2>
       <p>Use the filters to narrow formats by <strong>category</strong> and <strong>lifecycle stage</strong>. Click each item to expand details. Copy code with the button on the right.</p>
@@ -194,6 +405,13 @@
         <button data-filter-type="use-case" data-filter-value="Analytics">Analytics</button>
         <button data-filter-type="use-case" data-filter-value="Lakehouse">Lakehouse</button>
         <span class="small">Tip: Press <span class="kbd">/</span> to focus search</span>
+      </div>
+      <div class="report-callout">
+        <div>
+          <h3>New for 2025: Data Format Outlook</h3>
+          <p>Explore key trends, emerging formats, and adoption milestones in the interactive annual research report.</p>
+        </div>
+        <a class="cta-button" href="2025_Data_Format_Report.html">Read the 2025 Report</a>
       </div>
     </section>
     

--- a/index.html
+++ b/index.html
@@ -71,6 +71,10 @@
                     <h3 class="text-2xl font-bold text-amber-500 mb-2">Levels of Data Analytics</h3>
                     <p class="text-slate-600">Explore the progression from descriptive to prescriptive analytics.</p>
                 </a>
+                <a href="Big_Data_Formats.html" class="card bg-white p-6 rounded-lg shadow-md flex flex-col items-center justify-center text-center hover:shadow-xl">
+                    <h3 class="text-2xl font-bold text-amber-500 mb-2">Big Data Formats Explorer</h3>
+                    <p class="text-slate-600">Compare storage, serialization, and lakehouse formats with interactive filters.</p>
+                </a>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- add a home-page card that links directly to the Big Data Formats explorer
- refresh the Big_Data_Formats experience with the site-wide light theme, new navigation, and a callout to the 2025 report
- restyle the 2025 report to match the refreshed design and provide navigation back to the explorer and home page

## Testing
- not run (static content)


------
https://chatgpt.com/codex/tasks/task_e_68d3b77c059c8325b99750fc7d54b79e