### PR TITLE
Restyle Big Data Formats explorer and simplify intro

### DIFF
--- a/Big_Data_Formats.html
+++ b/Big_Data_Formats.html
@@ -9,17 +9,19 @@
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
 <style>
   :root {
-    --bg: #f8fafc;
+    --bg: #f8f7f4;
     --card: #ffffff;
-    --muted: #64748b;
-    --text: #1e293b;
-    --accent: #f59e0b;
-    --accent-lighter: #fbbf24;
-    --accent2: #6366f1;
-    --border: #e2e8f0;
-    --good: #16a34a;
-    --warn: #f59e0b;
-    --bad: #ef4444;
+    --muted: #6b615b;
+    --text: #4a4a4a;
+    --accent: #8c7b72;
+    --accent-strong: #6f5f57;
+    --accent-light: #d3c1b9;
+    --accent2: #8c7b72;
+    --border: #eaddd7;
+    --border-strong: #c8b4ab;
+    --good: #2f855a;
+    --warn: #b7791f;
+    --bad: #c53030;
   }
   * { box-sizing: border-box; }
   body {
@@ -29,57 +31,42 @@
     color: var(--text);
   }
   a { color: var(--accent); text-decoration: none; }
-  a:hover { color: #d97706; }
-  header {
-    position: sticky;
-    top: 0;
-    z-index: 50;
-    backdrop-filter: blur(12px);
-    background: rgba(255,255,255,0.9);
-    border-bottom: 1px solid var(--border);
-    box-shadow: 0 12px 30px rgba(15,23,42,0.08);
-  }
-  .top-bar {
-    background: #fef3c7;
-    border-bottom: 1px solid #fde68a;
-    padding: 8px 0;
-  }
+  a:hover { color: var(--accent-strong); }
   .container {
     width: min(1200px, 92vw);
     margin: 0 auto;
   }
-  .top-bar .container {
+  .site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: #ece5e1;
+    border-bottom: 1px solid var(--border);
+    box-shadow: 0 4px 6px -1px rgba(0,0,0,0.05), 0 2px 4px -1px rgba(0,0,0,0.03);
+  }
+  .nav-bar {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    gap: 12px;
+    gap: 16px;
+    padding: 14px 0;
     flex-wrap: wrap;
   }
-  .top-bar a {
-    color: #b45309;
+  .home-button {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
     font-weight: 600;
-    font-size: 14px;
+    color: var(--accent);
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    padding: 8px 18px;
+    transition: all 0.2s ease;
   }
-  .top-bar a:hover {
-    color: #92400e;
-  }
-  .header-content {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    gap: 24px;
-    padding: 20px 0;
-    flex-wrap: wrap;
-  }
-  .header-content h1 {
-    font-size: 2.25rem;
-    margin: 0;
-    color: var(--text);
-  }
-  .subtitle {
-    margin: 6px 0 0;
-    color: var(--muted);
-    max-width: 520px;
+  .home-button:hover {
+    border-color: var(--accent);
+    background: #f1e6e1;
   }
   .nav-actions {
     display: flex;
@@ -89,39 +76,32 @@
   .nav-actions a {
     display: inline-flex;
     align-items: center;
-    gap: 8px;
     font-weight: 600;
-    color: #1f2937;
+    color: #63534d;
     font-size: 14px;
-    padding: 8px 12px;
-    border-radius: 10px;
+    padding: 8px 16px;
+    border-radius: 999px;
     border: 1px solid var(--border);
-    background: #ffffff;
+    background: rgba(255,255,255,0.7);
     transition: all 0.2s ease;
   }
   .nav-actions a:hover {
     border-color: var(--accent);
-    box-shadow: 0 12px 28px rgba(245,158,11,0.18);
-    color: #92400e;
-  }
-  .pill {
-    color: #b45309;
-    background: #fef3c7;
-    border: 1px solid #fde68a;
-    padding: 6px 12px;
-    border-radius: 999px;
-    font-weight: 600;
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
+    box-shadow: 0 12px 22px rgba(99,83,77,0.18);
+    color: var(--accent);
+    background: rgba(255,255,255,0.95);
   }
   .page {
-    padding: 32px 0 64px;
+    padding: 48px 0 72px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
   }
-  h1, h2, h3 { margin: 0.6em 0 0.4em; }
-  h2 { font-size: 1.6rem; color: #1e293b; }
-  h3 { font-size: 1.2rem; color: #4338ca; }
-  p { color: var(--muted); line-height: 1.65; }
+  h1, h2, h3 { margin: 0; }
+  h1 { font-size: 2.5rem; color: #63534d; }
+  h2 { font-size: 1.75rem; color: #63534d; }
+  h3 { font-size: 1.25rem; color: #6f5f57; }
+  p { color: var(--muted); line-height: 1.7; margin: 0; }
   .grid {
     display: grid;
     gap: 16px;
@@ -131,18 +111,54 @@
   .card {
     background: var(--card);
     border: 1px solid var(--border);
-    border-radius: 16px;
-    padding: 20px 22px;
-    box-shadow: 0 12px 28px rgba(15,23,42,0.08);
+    border-radius: 20px;
+    padding: 28px;
+    box-shadow: 0 15px 30px rgba(99,83,77,0.08);
     transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
   }
   .card:hover {
-    transform: translateY(-4px);
-    box-shadow: 0 22px 40px rgba(15,23,42,0.12);
+    transform: translateY(-2px);
+    box-shadow: 0 22px 44px rgba(99,83,77,0.12);
   }
   .card.highlight {
     border-color: var(--accent);
-    box-shadow: 0 18px 36px rgba(245,158,11,0.22);
+    box-shadow: 0 22px 44px rgba(99,83,77,0.18);
+  }
+  .hero-card {
+    background: linear-gradient(135deg, rgba(236,229,225,0.6), rgba(255,255,255,0.95));
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .hero-card__heading {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+  }
+  .lead {
+    font-size: 1.1rem;
+    color: var(--text);
+  }
+  .pill {
+    color: #63534d;
+    background: #ece5e1;
+    border: 1px solid var(--border);
+    padding: 6px 12px;
+    border-radius: 999px;
+    font-weight: 600;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .filters-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+  .filters-panel__header {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
   }
   .tag {
     display: inline-flex;
@@ -152,49 +168,50 @@
     margin: 2px 6px 2px 0;
     border-radius: 999px;
     border: 1px solid var(--border);
-    background: #f1f5f9;
-    color: #475569;
+    background: #f5ede9;
+    color: #63534d;
     font-weight: 500;
   }
   .tag.good {
-    border-color: rgba(134,239,172,0.6);
-    background: rgba(187,247,208,0.7);
-    color: #166534;
+    border-color: rgba(72,187,120,0.4);
+    background: rgba(72,187,120,0.12);
+    color: #276749;
   }
   .tag.warn {
-    border-color: rgba(253,230,138,0.9);
-    background: rgba(254,243,199,0.85);
-    color: #92400e;
+    border-color: rgba(236,201,75,0.55);
+    background: rgba(236,201,75,0.18);
+    color: #8b5e11;
   }
   .tag.bad {
-    border-color: rgba(254,202,202,0.7);
-    background: rgba(254,226,226,0.85);
-    color: #b91c1c;
+    border-color: rgba(229,62,62,0.45);
+    background: rgba(229,62,62,0.16);
+    color: #822727;
   }
   details {
     border: 1px solid var(--border);
-    border-radius: 12px;
-    padding: 12px 16px;
+    border-radius: 14px;
+    padding: 14px 18px;
     margin: 12px 0;
-    background: #f8fafc;
+    background: #f4ede9;
+    transition: border-color 0.2s ease, background 0.2s ease;
   }
   details[open] {
-    background: #fff7ed;
-    border-color: #fbbf24;
+    background: #efe2db;
+    border-color: var(--accent);
   }
   summary {
     cursor: pointer;
     font-weight: 600;
-    color: #b45309;
+    color: var(--accent);
   }
   summary:hover { text-decoration: underline; }
   code, pre {
-    background: #0f172a;
-    border: 1px solid #1e293b;
-    border-radius: 10px;
-    color: #e2e8f0;
+    background: #2f2a26;
+    border: 1px solid #4a4039;
+    border-radius: 12px;
+    color: #f5ede5;
   }
-  code { padding: 2px 6px; display: inline-block; }
+  code { padding: 2px 8px; display: inline-block; }
   pre { padding: 12px; overflow: auto; }
   .row { display:flex; align-items:center; gap:12px; flex-wrap: wrap; }
   .toolbar {
@@ -204,21 +221,21 @@
     align-items: center;
     padding: 16px;
     border:1px solid var(--border);
-    border-radius: 14px;
-    background: #f1f5f9;
+    border-radius: 16px;
+    background: rgba(236,229,225,0.55);
   }
   input[type="search"], select, button {
-    background: #ffffff;
+    background: var(--card);
     color: var(--text);
     border:1px solid var(--border);
     padding:10px 12px;
-    border-radius: 10px;
+    border-radius: 12px;
     outline: none;
     transition: border-color 0.2s ease, box-shadow 0.2s ease;
   }
   input[type="search"]:focus, select:focus {
     border-color: var(--accent);
-    box-shadow: 0 0 0 3px rgba(245,158,11,0.25);
+    box-shadow: 0 0 0 3px rgba(140,123,114,0.25);
   }
   .toolbar button {
     cursor: pointer;
@@ -228,24 +245,24 @@
     font-weight: 600;
   }
   .toolbar button:hover {
-    background: #d97706;
-    border-color: #d97706;
+    background: var(--accent-strong);
+    border-color: var(--accent-strong);
   }
   .copy-btn {
     float: right;
     margin-left: 8px;
     padding: 4px 10px;
     font-size: 12px;
-    background: #f8fafc;
-    color: #334155;
+    background: #f8f1ec;
+    color: #63534d;
     border:1px solid var(--border);
     border-radius: 8px;
     cursor: pointer;
     transition: background 0.2s ease, color 0.2s ease, transform 0.2s ease;
   }
   .copy-btn:hover {
-    background: #e2e8f0;
-    color: #1e293b;
+    background: #ede0d8;
+    color: var(--accent-strong);
     transform: translateY(-1px);
   }
   table { width: 100%; border-collapse: collapse; }
@@ -258,27 +275,31 @@
   th {
     position: sticky;
     top: 0;
-    background: rgba(248,250,252,0.95);
-    backdrop-filter: blur(6px);
+    background: rgba(248,244,240,0.95);
+    backdrop-filter: blur(4px);
     z-index:1;
     cursor: pointer;
     transition: color 0.2s ease;
     font-weight: 600;
-    color: #475569;
+    color: #574840;
   }
   th:hover { color: var(--accent); }
-  tbody tr:hover { background: #fff7ed; }
-  .small { font-size: 12px; color:#94a3b8; }
-  .section { margin-top: 32px; }
-  .kbd { border:1px solid #cbd5f5; background:#eef2ff; padding:2px 6px; border-radius:6px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; color:#4338ca; }
-  footer { color:#94a3b8; font-size: 12px; margin-top: 40px; text-align:center; }
-  .highlight-row { background-color: rgba(251,191,36,0.2); }
+  tbody tr:hover { background: rgba(236,229,225,0.45); }
+  .small { font-size: 12px; color:#8c7b72; }
+  .section {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+  }
+  .kbd { border:1px solid #d3c1b9; background:#f5ede9; padding:2px 6px; border-radius:6px; font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; font-size: 12px; color:#6f5f57; }
+  footer { color:#8c7b72; font-size: 12px; margin-top: 40px; text-align:center; }
+  .highlight-row { background-color: rgba(140,123,114,0.18); }
   .concept-card {
-    background: linear-gradient(135deg, rgba(99,102,241,0.08), rgba(59,130,246,0.05));
-    border: 1px solid rgba(99,102,241,0.25);
+    background: linear-gradient(135deg, rgba(140,123,114,0.08), rgba(234,221,215,0.6));
+    border: 1px solid rgba(140,123,114,0.25);
     margin-bottom: 16px;
   }
-  .concept-card h3 { margin-top: 0; color: #4338ca; }
+  .concept-card h3 { margin-top: 0; color: #6f5f57; }
   .concept-card p { margin-bottom: 0; }
   .flow-diagram-container {
     display: flex;
@@ -287,13 +308,13 @@
     flex-wrap: wrap;
     gap: 20px;
     padding: 20px;
-    background: linear-gradient(135deg, rgba(251,191,36,0.18), rgba(236,233,254,0.8));
-    border-radius: 12px;
-    border: 1px solid rgba(251,191,36,0.45);
+    background: linear-gradient(135deg, rgba(236,229,225,0.7), rgba(255,255,255,0.8));
+    border-radius: 16px;
+    border: 1px solid rgba(140,123,114,0.3);
   }
   .flow-step {
     text-align: center;
-    color: #b45309;
+    color: var(--accent);
     font-weight: 600;
   }
   .flow-arrow {
@@ -302,31 +323,31 @@
     transform: rotate(90deg);
   }
   .report-callout {
-    margin-top: 20px;
+    margin-top: 12px;
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
     gap: 16px;
-    padding: 16px 18px;
-    border-radius: 14px;
-    background: linear-gradient(135deg, rgba(245,158,11,0.15), rgba(99,102,241,0.15));
-    border: 1px solid rgba(245,158,11,0.35);
+    padding: 18px 20px;
+    border-radius: 16px;
+    background: linear-gradient(135deg, rgba(140,123,114,0.18), rgba(217,198,189,0.25));
+    border: 1px solid rgba(140,123,114,0.35);
   }
   .report-callout h3 {
     margin: 0;
-    color: #92400e;
+    color: #56443d;
   }
   .report-callout p {
     margin: 4px 0 0;
-    color: #475569;
+    color: var(--muted);
   }
   .cta-button {
     display: inline-flex;
     align-items: center;
     gap: 8px;
     padding: 10px 16px;
-    border-radius: 10px;
+    border-radius: 999px;
     background: var(--accent);
     color: #ffffff;
     font-weight: 600;
@@ -334,10 +355,15 @@
     transition: background 0.2s ease, box-shadow 0.2s ease;
   }
   .cta-button:hover {
-    background: #d97706;
-    box-shadow: 0 16px 32px rgba(245,158,11,0.25);
+    background: var(--accent-strong);
+    box-shadow: 0 16px 28px rgba(111,95,87,0.25);
   }
-  @media (min-width: 600px) {
+  @media (min-width: 640px) {
+    .hero-card__heading {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+    }
     .flow-arrow {
       transform: none;
     }
@@ -350,39 +376,38 @@
       width: 100%;
     }
     .nav-actions a {
-      flex: 1 1 100%;
+      flex: 1 1 auto;
       justify-content: center;
-    }
-    .header-content {
-      align-items: flex-start;
     }
   }
 </style>
 </head>
 <body>
-  <header>
-    <div class="top-bar">
-      <div class="container">
-        <a href="index.html">&larr; Back to main navigation</a>
-        <div class="nav-actions">
-          <a href="#summary">Jump to comparison table</a>
-          <a href="2025_Data_Format_Report.html">View the 2025 Data Format Report</a>
-        </div>
+  <header class="site-header">
+    <nav class="container nav-bar">
+      <a class="home-button" href="index.html">Home</a>
+      <div class="nav-actions">
+        <a href="#summary">Comparison Table</a>
+        <a href="2025_Data_Format_Report.html">2025 Data Format Report</a>
       </div>
-    </div>
-    <div class="container header-content">
-      <div>
-        <h1>Big Data Formats Explorer</h1>
-        <p class="subtitle">Identify the right file, table, and serialization formats for ingestion, analytics, streaming, and lakehouse workloads.</p>
-      </div>
-      <span class="pill">CSV · JSON · XML · Parquet · ORC · Arrow · Avro · Protobuf · Thrift · SequenceFile · TFRecord · HDF5 · NetCDF · Delta · Iceberg · Hudi · Kudu</span>
-    </div>
+    </nav>
   </header>
 
   <main class="container page">
-    <section class="card">
-      <h2>How to use this guide</h2>
-      <p>Use the filters to narrow formats by <strong>category</strong> and <strong>lifecycle stage</strong>. Click each item to expand details. Copy code with the button on the right.</p>
+    <section class="card hero-card">
+      <div class="hero-card__heading">
+        <h1>Big Data Formats Explorer</h1>
+        <span class="pill">CSV · JSON · XML · Parquet · ORC · Arrow · Avro · Protobuf · Thrift · SequenceFile · TFRecord · HDF5 · NetCDF · Delta · Iceberg · Hudi · Kudu</span>
+      </div>
+      <p class="lead">Identify the right file, table, and serialization formats for ingestion, analytics, streaming, and lakehouse workloads.</p>
+      <p>Scan the curated library to understand lifecycle fit, compare strengths in the sortable summary table, and open each card for implementation notes and examples.</p>
+    </section>
+
+    <section class="card filters-panel">
+      <div class="filters-panel__header">
+        <h2>Explore the library</h2>
+        <p>Search across formats or focus on a lifecycle stage to surface the structures that match your pipeline.</p>
+      </div>
       <div class="toolbar">
         <input id="search" type="search" placeholder="Search formats, tech, scenarios…" />
         <select id="category">


### PR DESCRIPTION
## Summary
- Refresh the Big Data Formats page with the warm neutral palette and card styling used on the Levels of Analytics guide.
- Replace the back arrow with a prominent Home button and add a hero introduction that mirrors the analytics layout.
- Reorganize the filters section to keep the interactive controls while removing the confusing "How to use this guide" block.

## Testing
- No automated tests were run (static HTML/CSS change).


------
https://chatgpt.com/codex/tasks/task_e_68d3c976ddec8325a5b0c88eea07f631