### PR TITLE
Set backgrounds across HTML pages to light blue

### DIFF
--- a/2025_Data_Format_Report.html
+++ b/2025_Data_Format_Report.html
@@ -16,7 +16,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc;
+            background-color: #add8e6;
             color: #334155;
         }
         .container {

--- a/Apache_Cassandra.html
+++ b/Apache_Cassandra.html
@@ -22,7 +22,7 @@
         }
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc;
+            background-color: #add8e6;
         }
         .nav-link {
             transition: all 0.2s ease-in-out;

--- a/Apache_Hive.html
+++ b/Apache_Hive.html
@@ -22,7 +22,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #F8F9FA;
+            background-color: #add8e6;
             color: #212529;
         }
         .chart-container {

--- a/Apache_Pig.html
+++ b/Apache_Pig.html
@@ -22,7 +22,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #fdfdfd;
+            background-color: #add8e6;
             color: #333;
         }
         .chart-container {

--- a/Apache_Spark.html
+++ b/Apache_Spark.html
@@ -23,7 +23,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc;
+            background-color: #add8e6;
             color: #1e293b;
         }
         .chart-container {

--- a/Big_Data_Formats.html
+++ b/Big_Data_Formats.html
@@ -27,7 +27,7 @@
   body {
     margin: 0;
     font-family: 'Inter', sans-serif;
-    background: var(--bg);
+    background-color: #add8e6;
     color: var(--text);
   }
   a { color: var(--accent); text-decoration: none; }

--- a/Big_Data_Processing.html
+++ b/Big_Data_Processing.html
@@ -22,7 +22,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc; /* slate-50 */
+            background-color: #add8e6; /* light blue */
             color: #334155; /* slate-700 */
         }
         .nav-link {

--- a/Big_Data_Storage_Concepts.html
+++ b/Big_Data_Storage_Concepts.html
@@ -17,7 +17,7 @@
     -->
     <!-- CONFIRMATION: NO SVG graphics used. NO Mermaid JS used. -->
     <style>
-        body { font-family: 'Inter', sans-serif; scroll-behavior: smooth; }
+        body { background-color: #add8e6; font-family: 'Inter', sans-serif; scroll-behavior: smooth; }
         .chart-container { position: relative; width: 100%; max-width: 500px; margin-left: auto; margin-right: auto; height: 350px; max-height: 400px; }
         .data-block { transition: all 0.5s ease-in-out; }
         .replica-flow { transition: all 1s ease-in-out; }

--- a/Business_Value_Modeler.html
+++ b/Business_Value_Modeler.html
@@ -18,11 +18,9 @@
       --card:#0b1220;       /* deep panel */
       --shadow: 0 10px 30px rgba(0,0,0,.35);
     }
-    html, body { height: 100%; }
+    html, body { background-color: #add8e6; height: 100%; }
     body{
-      margin:0; background: radial-gradient(1200px 600px at 80% -10%, rgba(34,211,238,.10), transparent),
-                                  radial-gradient(900px 400px at -10% 10%, rgba(167,139,250,.10), transparent),
-                                  var(--bg);
+      margin:0; background-color: #add8e6;
       color:var(--text); font: 15px/1.45 system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
     }
     .wrap{ max-width:1200px; margin:0 auto; padding:24px; }

--- a/Hadoop_Cluster_Setup.html
+++ b/Hadoop_Cluster_Setup.html
@@ -11,7 +11,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f7f9fb;
+            background-color: #add8e6;
             color: #333;
         }
         .code-block {

--- a/Hadoop_Ecosystem.html
+++ b/Hadoop_Ecosystem.html
@@ -23,7 +23,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc;
+            background-color: #add8e6;
             color: #1e293b;
         }
         .nav-link {

--- a/Hadoop_Fundamentals.html
+++ b/Hadoop_Fundamentals.html
@@ -23,7 +23,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc; /* slate-50 */
+            background-color: #add8e6; /* light blue */
             color: #334155; /* slate-700 */
         }
         .nav-link {

--- a/Hadoop_Infrastructure_Estimator.html
+++ b/Hadoop_Infrastructure_Estimator.html
@@ -19,7 +19,7 @@
     --shadow: 0 10px 25px rgba(0,0,0,.25);
   }
   * { box-sizing: border-box; }
-  body{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji"; background:linear-gradient(180deg, #0b1223, #0f172a); color:var(--text); }
+  body{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji"; background-color: #add8e6; color:var(--text); }
   header{ position:sticky; top:0; z-index:10; backdrop-filter: blur(6px); background: linear-gradient(90deg, rgba(15,23,42,.9), rgba(17,24,39,.9)); border-bottom: 1px solid rgba(255,255,255,.08); }
   .shell{ max-width:1300px; margin:0 auto; padding:14px 18px; }
   h1{ margin:0; font-size:1.35rem; letter-spacing:.2px; font-weight:700; display:flex; align-items:center; gap:.6rem; }

--- a/Hadoop_Simulation_New.html
+++ b/Hadoop_Simulation_New.html
@@ -16,10 +16,10 @@
       --bad:#fb7185; /* rose-400 */
       --line:#334155; /* slate-700 */
     }
-    html,body{height:100%;}
+    html,body{background-color:#add8e6;height:100%;}
     body{
       margin:0; font-family:ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica Neue, Arial, "Apple Color Emoji", "Segoe UI Emoji";
-      color:#e5e7eb; background:linear-gradient(180deg,#0b1225, #0f172a 40%, #0b1225);
+      color:#e5e7eb; background-color:#add8e6;
     }
     header{position:sticky; top:0; z-index:10; backdrop-filter:saturate(140%) blur(6px); background:rgba(17,24,39,.7); border-bottom:1px solid #1f2937}
     .wrap{max-width:1100px; margin:0 auto; padding:18px 16px;}

--- a/Levels_of_Data_Analytics.html
+++ b/Levels_of_Data_Analytics.html
@@ -20,7 +20,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8f7f4;
+            background-color: #add8e6;
             color: #4a4a4a;
         }
         .nav-link {

--- a/Levels_of_Data_Analytics_Practice_Questions.html
+++ b/Levels_of_Data_Analytics_Practice_Questions.html
@@ -11,7 +11,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8f7f4;
+            background-color: #add8e6;
             color: #4a4a4a;
             display: flex;
             justify-content: center;

--- a/Map_Reduce.html
+++ b/Map_Reduce.html
@@ -23,7 +23,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #F8F7F4; /* Warm Neutral Background */
+            background-color: #add8e6; /* light blue */
             color: #4A4A4A;
         }
         .bg-primary { background-color: #008080; } /* Teal */

--- a/Map_Reduce_Visual_Simulator.html
+++ b/Map_Reduce_Visual_Simulator.html
@@ -20,12 +20,10 @@
       --shadow: 0 8px 28px rgba(0,0,0,0.35);
     }
     *{box-sizing:border-box}
-    html,body{height:100%}
+    html,body{background-color:#add8e6;height:100%}
     body{
       margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
-      background: radial-gradient(1200px 600px at 20% -10%, #12203a 0%, transparent 60%),
-                  radial-gradient(1000px 600px at 90% 0%, #121a2a 0%, transparent 60%),
-                  var(--bg);
+      background-color:#add8e6;
       color:var(--text);
     }
     .app{max-width:1200px; margin:24px auto; padding:0 16px 56px}

--- a/MongoDB.html
+++ b/MongoDB.html
@@ -12,7 +12,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc; /* slate-50 */
+            background-color: #add8e6; /* light blue */
             color: #334155; /* slate-700 */
         }
         .nav-link {

--- a/NoSQL_Deep_Dive.html
+++ b/NoSQL_Deep_Dive.html
@@ -16,7 +16,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc; /* slate-50 */
+            background-color: #add8e6; /* light blue */
             color: #334155; /* slate-700 */
         }
         .nav-link {

--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
     <style>
         body {
             font-family: 'Inter', sans-serif;
-            background-color: #f8fafc; /* slate-50 */
+            background-color: #add8e6; /* light blue */
             color: #334155; /* slate-700 */
         }
         .nav-link {

--- a/mongodb-flashcards.html
+++ b/mongodb-flashcards.html
@@ -19,10 +19,10 @@
   }
 
   * { box-sizing: border-box; }
-  html, body { height: 100%; }
+  html, body { background-color: #add8e6; height: 100%; }
   body{
     margin:0;
-    background: linear-gradient(180deg, #0b1020 0%, #0f172a 100%);
+    background-color: #add8e6;
     color: var(--text);
     font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji";
     line-height: 1.5;
@@ -119,7 +119,7 @@
 
   /* PRINT (Export to PDF) */
   @media print{
-    body{ background:#ffffff; color:#000; }
+    body{ background-color:#add8e6; color:#000; }
     header, nav, .controls{ display:none !important; }
     .main{ padding:0; }
     .qcard{ break-inside: avoid; border:1px solid #aaa; background:#fff; }

--- a/record_size_estimator.html
+++ b/record_size_estimator.html
@@ -19,7 +19,7 @@
     --shadow: 0 10px 25px rgba(0,0,0,.25);
   }
   * { box-sizing: border-box; }
-  body{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji"; background:linear-gradient(180deg, #0b1223, #0f172a); color:var(--text); }
+  body{ margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji","Segoe UI Emoji"; background-color: #add8e6; color:var(--text); }
   header{ position:sticky; top:0; z-index:10; backdrop-filter: blur(6px); background: linear-gradient(90deg, rgba(15,23,42,.9), rgba(17,24,39,.9)); border-bottom: 1px solid rgba(255,255,255,.08); }
   .shell{ max-width:1300px; margin:0 auto; padding:14px 18px; }
   h1{ margin:0; font-size:1.35rem; letter-spacing:.2px; font-weight:700; display:flex; align-items:center; gap:.6rem; }


### PR DESCRIPTION
## Summary
- update each HTML page to use a consistent light blue body background
- adjust shared html/body styles and print rules on dark-themed pages to remove gradients

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914338e960883259eb55fecd6487ff1)